### PR TITLE
feature/TR-2249-add-missing-plugins

### DIFF
--- a/packages/ckeditor5-build-decoupled-document/package.json
+++ b/packages/ckeditor5-build-decoupled-document/package.json
@@ -41,6 +41,7 @@
     "@ckeditor/ckeditor5-essentials": "^37.1.0",
     "@ckeditor/ckeditor5-font": "^37.1.0",
     "@ckeditor/ckeditor5-heading": "^37.1.0",
+    "@ckeditor/ckeditor5-html-support": "^37.1.0",
     "@ckeditor/ckeditor5-image": "^37.1.0",
     "@ckeditor/ckeditor5-indent": "^37.1.0",
     "@ckeditor/ckeditor5-link": "^37.1.0",
@@ -48,12 +49,14 @@
     "@ckeditor/ckeditor5-media-embed": "^37.1.0",
     "@ckeditor/ckeditor5-paragraph": "^37.1.0",
     "@ckeditor/ckeditor5-paste-from-office": "^37.1.0",
+    "@ckeditor/ckeditor5-remove-format": "^37.1.0",
+    "@ckeditor/ckeditor5-source-editing": "^37.1.0",
+    "@ckeditor/ckeditor5-style": "^37.1.0",
     "@ckeditor/ckeditor5-table": "^37.1.0",
     "@ckeditor/ckeditor5-typing": "^37.1.0",
-    "@ftrprf/ckeditor5-iframe": "https://github.com/FTRPRF/ckeditor5-iframe.git",
-    "@ftrprf/ckeditor5-scratch-blocks": "0.0.3",
     "@ftrprf/ckeditor5-content-templates": "0.0.1",
-    "@ckeditor/ckeditor5-html-support": "^37.1.0"
+    "@ftrprf/ckeditor5-iframe": "https://github.com/FTRPRF/ckeditor5-iframe.git",
+    "@ftrprf/ckeditor5-scratch-blocks": "0.0.3"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-core": "^37.1.0",

--- a/packages/ckeditor5-build-decoupled-document/src/ckeditor.ts
+++ b/packages/ckeditor5-build-decoupled-document/src/ckeditor.ts
@@ -14,7 +14,7 @@ import {
 	FontSize,
 	FontFamily,
 	FontColor,
-	FontBackgroundColor,
+	FontBackgroundColor
 } from '@ckeditor/ckeditor5-font';
 import { UploadAdapter } from '@ckeditor/ckeditor5-adapter-ckfinder';
 import { Autoformat } from '@ckeditor/ckeditor5-autoformat';
@@ -23,6 +23,8 @@ import {
 	Italic,
 	Strikethrough,
 	Underline,
+	Superscript,
+	Subscript
 } from '@ckeditor/ckeditor5-basic-styles';
 import { BlockQuote } from '@ckeditor/ckeditor5-block-quote';
 import { CKBox } from '@ckeditor/ckeditor5-ckbox';
@@ -36,7 +38,7 @@ import {
 	ImageStyle,
 	ImageToolbar,
 	ImageUpload,
-	PictureEditing,
+	PictureEditing
 } from '@ckeditor/ckeditor5-image';
 import { Indent, IndentBlock } from '@ckeditor/ckeditor5-indent';
 import { Link } from '@ckeditor/ckeditor5-link';
@@ -47,6 +49,9 @@ import { PasteFromOffice } from '@ckeditor/ckeditor5-paste-from-office';
 import { Table, TableToolbar } from '@ckeditor/ckeditor5-table';
 import { TextTransformation } from '@ckeditor/ckeditor5-typing';
 import { CloudServices } from '@ckeditor/ckeditor5-cloud-services';
+import { FindAndReplace } from '@ckeditor/ckeditor5-find-and-replace';
+import { RemoveFormat } from '@ckeditor/ckeditor5-remove-format';
+import { SourceEditing } from '@ckeditor/ckeditor5-source-editing';
 
 import ClickObserver from '../../ckeditor5-engine/src/view/observer/clickobserver';
 import { GeneralHtmlSupport } from '../../ckeditor5-html-support/src/index';
@@ -99,10 +104,15 @@ export default class DecoupledEditor extends DecoupledEditorBase {
 		Table,
 		TableToolbar,
 		TextTransformation,
+		Superscript,
+		Subscript,
+		FindAndReplace,
+		RemoveFormat,
+		SourceEditing,
 		Iframe,
 		ScratchBlocks,
 		ContentTemplates,
-		Exercise,
+		Exercise
 	];
 
 	public static override defaultConfig = {
@@ -119,6 +129,8 @@ export default class DecoupledEditor extends DecoupledEditorBase {
 				'italic',
 				'underline',
 				'strikethrough',
+				'subscript',
+				'superscript',
 				'|',
 				'alignment',
 				'|',
@@ -129,7 +141,6 @@ export default class DecoupledEditor extends DecoupledEditorBase {
 				'indent',
 				'|',
 				'link',
-				'blockquote',
 				'uploadImage',
 				'insertTable',
 				'mediaEmbed',
@@ -137,11 +148,16 @@ export default class DecoupledEditor extends DecoupledEditorBase {
 				'undo',
 				'redo',
 				'|',
+				'sourceEditing',
+				'removeFormat',
+				'|',
+				'style',
+				'|',
 				'iframe',
 				'scratchBlocks',
 				'contentTemplates',
-				'exercise',
-			],
+				'exercise'
+			]
 		},
 		image: {
 			resizeUnit: 'px' as const,
@@ -151,21 +167,21 @@ export default class DecoupledEditor extends DecoupledEditorBase {
 				'imageStyle:breakText',
 				'|',
 				'toggleImageCaption',
-				'imageTextAlternative',
-			],
+				'imageTextAlternative'
+			]
 		},
 		table: {
-			contentToolbar: ['tableColumn', 'tableRow', 'mergeTableCells'],
+			contentToolbar: ['tableColumn', 'tableRow', 'mergeTableCells']
 		},
 		list: {
 			properties: {
 				styles: true,
 				startIndex: true,
-				reversed: true,
-			},
+				reversed: true
+			}
 		},
 
 		// This value must be kept in sync with the language defined in webpack.config.js.
-		language: 'en',
+		language: 'en'
 	};
 }


### PR DESCRIPTION
# Pull Request

## Add missing plugins to ck5

Description:
- add missing plugins, that were in ck4 and not yet in ck5

### Additional information

**important**: 
2 pain points, maximize plugin (doesn't exist yet) and copy format plugin (is commercial license = expensive) couldn't be added

Ticket: [TR-2249](https://codefever.atlassian.net/browse/TR-2249) - [CKE5] Align plugins CKE4 and CKE5


[TR-2249]: https://codefever.atlassian.net/browse/TR-2249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ