### PR TITLE
remove source plugin, aka source editing, since its not supported for…

### DIFF
--- a/packages/ckeditor5-build-decoupled-document/package.json
+++ b/packages/ckeditor5-build-decoupled-document/package.json
@@ -50,7 +50,6 @@
     "@ckeditor/ckeditor5-paragraph": "^37.1.0",
     "@ckeditor/ckeditor5-paste-from-office": "^37.1.0",
     "@ckeditor/ckeditor5-remove-format": "^37.1.0",
-    "@ckeditor/ckeditor5-source-editing": "^37.1.0",
     "@ckeditor/ckeditor5-style": "^37.1.0",
     "@ckeditor/ckeditor5-table": "^37.1.0",
     "@ckeditor/ckeditor5-typing": "^37.1.0",

--- a/packages/ckeditor5-build-decoupled-document/src/ckeditor.ts
+++ b/packages/ckeditor5-build-decoupled-document/src/ckeditor.ts
@@ -51,7 +51,6 @@ import { TextTransformation } from '@ckeditor/ckeditor5-typing';
 import { CloudServices } from '@ckeditor/ckeditor5-cloud-services';
 import { FindAndReplace } from '@ckeditor/ckeditor5-find-and-replace';
 import { RemoveFormat } from '@ckeditor/ckeditor5-remove-format';
-import { SourceEditing } from '@ckeditor/ckeditor5-source-editing';
 
 import ClickObserver from '../../ckeditor5-engine/src/view/observer/clickobserver';
 import { GeneralHtmlSupport } from '../../ckeditor5-html-support/src/index';
@@ -111,7 +110,6 @@ export default class DecoupledEditor extends DecoupledEditorBase {
 		Subscript,
 		FindAndReplace,
 		RemoveFormat,
-		SourceEditing,
 		Iframe,
 		ScratchBlocks,
 		ContentTemplates,
@@ -153,7 +151,6 @@ export default class DecoupledEditor extends DecoupledEditorBase {
 				'undo',
 				'redo',
 				'|',
-				'sourceEditing',
 				'removeFormat',
 				'|',
 				'style',


### PR DESCRIPTION
Remove the source-plugin from the editor decoupled document build, since it only works (for now, 12/06/2023) with the classic editor.  We will build or own to replace it (see https://codefever.atlassian.net/browse/TR-2314).

See: https://codefever.atlassian.net/browse/TR-2327