### PR TITLE
Feature/tr 2400 add image resize

### DIFF
--- a/.github/workflows/update-blob-imageResize.yml
+++ b/.github/workflows/update-blob-imageResize.yml
@@ -1,0 +1,28 @@
+name: Update CKEditor 5 blob dev
+
+on:
+    push:
+        branches:
+            - imageResize
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v3
+            - name: Setup Node
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 16
+                  registry-url: "https://npm.pkg.github.com"
+                  scope: "@ftrprf"
+            - name: Build editor
+              run: cd ./packages/ckeditor5-build-decoupled-document && pwd && npm install && npm run build
+              env:
+                  NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+            - name: upload to storage
+              env:
+                  AZURE_STORAGE_ACCOUNT: "ckeditorbuild"
+                  AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_BLOB_STORAGE_DEV_CONNECTION_STRING }}
+              run: az storage blob upload -f ./packages/ckeditor5-build-decoupled-document/build/ckeditor.js -c \ckeditor -n ckeditor5ImageResize.js --overwrite

--- a/.github/workflows/update-blob-imageResize.yml
+++ b/.github/workflows/update-blob-imageResize.yml
@@ -3,7 +3,7 @@ name: Update CKEditor 5 blob dev
 on:
     push:
         branches:
-            - imageResize
+            - feature/TR-2400-add-image-resize
 
 jobs:
     build:

--- a/README.md
+++ b/README.md
@@ -140,19 +140,9 @@ The development repository of CKEditor 5 is located at [https://github.com/ckedi
 
 ### Development
 
-CKEditor 5 is a modular, multi-package, [monorepo](https://en.wikipedia.org/wiki/Monorepo) project. It consists of several packages that create the editing framework, based on which the feature packages are implemented.
-
-The [`ckeditor5`](https://github.com/ckeditor/ckeditor5) repository is the place that centralizes the development of CKEditor 5. It bundles different packages into a single place, adding the necessary helper tools for the development workflow, like the builder and the test runner. [Basic information on how to set up the development environment](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/development-environment.html) can be found in the documentation.
-
-See the [official contributors' guide](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/contributing.html) to learn how to contribute your code to the project.
-
-### Reporting issues and feature requests
-
-Report issues in [the `ckeditor5` repository](https://github.com/ckeditor/ckeditor5/issues). Read more on the [Getting support](https://ckeditor.com/docs/ckeditor5/latest/support/getting-support.html) guide.
-
-## License
-
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+- add changes to ckeditor5-build-decoupled-document
+- add a workflow for the changes in .github
+- add the right environment variable to your studio .env file and get going
 
 
 ## How to trigger a build

--- a/README.md
+++ b/README.md
@@ -142,7 +142,16 @@ The development repository of CKEditor 5 is located at [https://github.com/ckedi
 
 - add changes to ckeditor5-build-decoupled-document
 - add a workflow for the changes in .github
-- add the right environment variable to your studio .env file and get going
+- add the right environment variable to your studio .env file and get going.  The format for the value of the
+  environment variable will be:
+```.env
+https://ckeditorbuilddev.blob.core.windows.net/ckeditor/{name_you_picked}.js
+```
+
+eg:
+```.env
+https://ckeditorbuilddev.blob.core.windows.net/ckeditor/ckeditor5ImageResize.js
+```
 
 
 ## How to trigger a build

--- a/packages/ckeditor5-build-decoupled-document/src/ckeditor.ts
+++ b/packages/ckeditor5-build-decoupled-document/src/ckeditor.ts
@@ -186,7 +186,39 @@ export default class DecoupledEditor extends DecoupledEditorBase {
 			],
 		},
 		image: {
-			resizeUnit: 'px' as const,
+			resizeUnit: '%' as const,
+			resizeOptions: [
+				{
+					name: 'resizeImage:original',
+					value: null,
+					label: 'Original'
+				},
+				{
+					name: 'resizeImage:14',
+					value: '14',
+					label: '14%'
+				},
+				{
+					name: 'resizeImage:24',
+					value: '24',
+					label: '24%'
+				},
+				{
+					name: 'resizeImage:38',
+					value: '38',
+					label: '38%'
+				},
+				{
+					name: 'resizeImage:50',
+					value: '50',
+					label: '50%'
+				},
+				{
+					name: 'resizeImage:62',
+					value: '62',
+					label: '62%'
+				},
+			],
 			toolbar: [
 				'imageStyle:inline',
 				'imageStyle:wrapText',
@@ -194,6 +226,7 @@ export default class DecoupledEditor extends DecoupledEditorBase {
 				'|',
 				'toggleImageCaption',
 				'imageTextAlternative',
+				'imageResize'
 			],
 		},
 		table: {


### PR DESCRIPTION
feature/TR-2400 Add image resize

Prior to this change resizing an image wasn't a thing other than by dragging.

This change adds resize buttons to the image toolbar according to the golden ratio & the desires of the content team.

To test: REACT_APP_CKEDITOR5_URL=https://ckeditorbuilddev.blob.core.windows.net/ckeditor/ckeditor5ImageResize.js in studio .env

See:
- https://en.wikipedia.org/wiki/Golden_ratio
- https://codefever.atlassian.net/browse/TR-2400
- https://ckeditor.com/docs/ckeditor5/latest/features/images/images-resizing.html