### PR TITLE
Feature/TR-2534: Switch percentages to their px counterpart

### DIFF
--- a/packages/ckeditor5-build-decoupled-document/src/ckeditor.ts
+++ b/packages/ckeditor5-build-decoupled-document/src/ckeditor.ts
@@ -198,22 +198,22 @@ export default class DecoupledEditor extends DecoupledEditorBase {
 					label: 'Original'
 				},
 				{
-					name: 'resizeImage:14',
+					name: 'resizeImage:10',
 					value: '126',
 					label: '10%'
 				},
 				{
-					name: 'resizeImage:24',
+					name: 'resizeImage:20',
 					value: '253',
 					label: '20%'
 				},
 				{
-					name: 'resizeImage:38',
+					name: 'resizeImage:30',
 					value: '380',
 					label: '30%'
 				},
 				{
-					name: 'resizeImage:38',
+					name: 'resizeImage:40',
 					value: '506',
 					label: '40%'
 				},
@@ -223,27 +223,27 @@ export default class DecoupledEditor extends DecoupledEditorBase {
 					label: '50%'
 				},
 				{
-					name: 'resizeImage:38',
+					name: 'resizeImage:60',
 					value: '760',
 					label: '60%'
 				},
 				{
-					name: 'resizeImage:38',
+					name: 'resizeImage:70',
 					value: '886',
 					label: '70%'
 				},
 				{
-					name: 'resizeImage:38',
+					name: 'resizeImage:80',
 					value: '1013',
 					label: '80%'
 				},
 				{
-					name: 'resizeImage:38',
+					name: 'resizeImage:90',
 					value: '1139',
 					label: '90%'
 				},
 				{
-					name: 'resizeImage:38',
+					name: 'resizeImage:100',
 					value: '1266',
 					label: '100%'
 				}

--- a/packages/ckeditor5-build-decoupled-document/src/ckeditor.ts
+++ b/packages/ckeditor5-build-decoupled-document/src/ckeditor.ts
@@ -189,7 +189,8 @@ export default class DecoupledEditor extends DecoupledEditorBase {
 			]
 		},
 		image: {
-			resizeUnit: '%' as const,
+			resizeUnit: 'px' as const,
+			// Full available size of a slide = 1366px - 2x3rem padding = 1266px
 			resizeOptions: [
 				{
 					name: 'resizeImage:original',
@@ -198,32 +199,52 @@ export default class DecoupledEditor extends DecoupledEditorBase {
 				},
 				{
 					name: 'resizeImage:14',
-					value: '14',
-					label: '14%'
+					value: '126',
+					label: '10%'
 				},
 				{
 					name: 'resizeImage:24',
-					value: '24',
-					label: '24%'
+					value: '253',
+					label: '20%'
 				},
 				{
 					name: 'resizeImage:38',
-					value: '38',
-					label: '38%'
+					value: '380',
+					label: '30%'
+				},
+				{
+					name: 'resizeImage:38',
+					value: '506',
+					label: '40%'
 				},
 				{
 					name: 'resizeImage:50',
-					value: '50',
+					value: '633',
 					label: '50%'
 				},
 				{
-					name: 'resizeImage:62',
-					value: '62',
-					label: '62%'
+					name: 'resizeImage:38',
+					value: '760',
+					label: '60%'
 				},
 				{
-					name: 'resizeImage:100',
-					value: '100',
+					name: 'resizeImage:38',
+					value: '886',
+					label: '70%'
+				},
+				{
+					name: 'resizeImage:38',
+					value: '1013',
+					label: '80%'
+				},
+				{
+					name: 'resizeImage:38',
+					value: '1139',
+					label: '90%'
+				},
+				{
+					name: 'resizeImage:38',
+					value: '1266',
 					label: '100%'
 				}
 			],


### PR DESCRIPTION

Before this PR there were limited and tbh weird choices for image width + this didnt work as expected in tables or other elements. So lets switch them to px based values and see if this works easier.