### PR TITLE
Enhan/TR-3070 Add Diff Highlighting in codeblocks

### DIFF
--- a/.github/workflows/update-blob-under_dev.yml
+++ b/.github/workflows/update-blob-under_dev.yml
@@ -3,7 +3,7 @@ name: Update CKEditor 5 blob dev
 on:
     push:
         branches:
-            - bug/fix-image-insert
+            - enhan/TR-3070-add-dif-highlighting
 
 jobs:
     build:
@@ -25,4 +25,4 @@ jobs:
               env:
                   AZURE_STORAGE_ACCOUNT: "ckeditorbuild"
                   AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_BLOB_STORAGE_DEV_CONNECTION_STRING }}
-              run: az storage blob upload -f ./packages/ckeditor5-build-decoupled-document/build/ckeditor.js -c \ckeditor -n insertImage.js --overwrite
+              run: az storage blob upload -f ./packages/ckeditor5-build-decoupled-document/build/ckeditor.js -c \ckeditor -n diffHighlight.js --overwrite

--- a/packages/ckeditor5-build-decoupled-document/src/ckeditor.ts
+++ b/packages/ckeditor5-build-decoupled-document/src/ckeditor.ts
@@ -286,6 +286,7 @@ export default class DecoupledEditor extends DecoupledEditorBase {
 			languages: [
 				{ language: 'html', label: 'HTML' },
 				{ language: 'css', label: 'CSS' },
+				{ language: 'diff', label: 'Diff' },
 				{ language: 'javascript', label: 'JavaScript' },
 				{ language: 'python', label: 'Python' },
 				{ language: 'json', label: 'JSON' },


### PR DESCRIPTION
Prior to this change we could not highlight lines.

This change adds diff highlighting.

See: https://codefever.atlassian.net/browse/TR-3070

### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Type: Message. Closes #000.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
