### PR TITLE
bug/TR-3700 Add source editing plugin

### DIFF
--- a/.github/workflows/update-blob-under_dev.yml
+++ b/.github/workflows/update-blob-under_dev.yml
@@ -3,7 +3,7 @@ name: Update CKEditor 5 blob dev
 on:
     push:
         branches:
-            - enhan/TR-3070-add-dif-highlighting
+            - bug/TR-3700-Add-source-editing-plugin
 
 jobs:
     build:
@@ -25,4 +25,4 @@ jobs:
               env:
                   AZURE_STORAGE_ACCOUNT: "ckeditorbuild"
                   AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_BLOB_STORAGE_DEV_CONNECTION_STRING }}
-              run: az storage blob upload -f ./packages/ckeditor5-build-decoupled-document/build/ckeditor.js -c \ckeditor -n diffHighlight.js --overwrite
+              run: az storage blob upload -f ./packages/ckeditor5-build-decoupled-document/build/ckeditor.js -c \ckeditor -n sourceEditing.js --overwrite

--- a/packages/ckeditor5-build-decoupled-document/src/ckeditor.ts
+++ b/packages/ckeditor5-build-decoupled-document/src/ckeditor.ts
@@ -55,6 +55,7 @@ import { CloudServices } from '@ckeditor/ckeditor5-cloud-services';
 import { FindAndReplace } from '@ckeditor/ckeditor5-find-and-replace';
 import { RemoveFormat } from '@ckeditor/ckeditor5-remove-format';
 import { CodeBlock } from '@ckeditor/ckeditor5-code-block';
+import SourceEditing from '@ckeditor/ckeditor5-source-editing/src/sourceediting.js';
 
 // eslint-disable-next-line ckeditor5-rules/allow-imports-only-from-main-package-entry-point
 import ClickObserver from '@ckeditor/ckeditor5-engine/src/view/observer/clickobserver.js';
@@ -138,6 +139,7 @@ export default class DecoupledEditor extends DecoupledEditorBase {
 		Style,
 		StyledLink,
 		Source,
+		SourceEditing,
 		Subscript,
 		Superscript,
 		Table,
@@ -196,7 +198,8 @@ export default class DecoupledEditor extends DecoupledEditorBase {
 				'styledLink',
 				'fullScreen',
 				'source',
-				'htmlInsert'
+				'sourceEditing',
+				'htmlInsert',
 			]
 		},
 		image: {


### PR DESCRIPTION
Prior to this change we used our own plugin for source editing the html in the ckeditor.

This change uses the inbuilt editor.

See: https://codefever.atlassian.net/browse/TR-3700

### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Type: Message. Closes #000.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
